### PR TITLE
added remap to match tiago odom topic

### DIFF
--- a/navigation_system/launch/navigation_launch.py
+++ b/navigation_system/launch/navigation_launch.py
@@ -47,7 +47,8 @@ def generate_launch_description():
     # TODO(orduno) Substitute with `PushNodeRemapping`
     #              https://github.com/ros2/launch_ros/issues/56
     remappings = [('/tf', 'tf'),
-                  ('/tf_static', 'tf_static')]
+                  ('/tf_static', 'tf_static'),
+                  ('odom', 'mobile_base_controller/odom')]
 
     # Create our own temporary YAML files that include substitutions
     param_substitutions = {

--- a/navigation_system/launch/navigation_system.launch.py
+++ b/navigation_system/launch/navigation_system.launch.py
@@ -103,7 +103,7 @@ def generate_launch_description():
 
     slam_cmd = IncludeLaunchDescription(
         PythonLaunchDescriptionSource(
-            os.path.join(slam_dir, 'launch', 'online_sync_launch.py')
+            os.path.join(slam_dir, 'launch', 'online_async_launch.py')
         ),
         launch_arguments={
             'use_sim_time': use_sim_time,


### PR DESCRIPTION
i discover that the tiago params we use for navigation do not suscribe to the real odom topic. instead of changing the params is easier to put a remap in the launcher. 